### PR TITLE
Test header guards on heat.h, bmi.h, and bmi_heat.h

### DIFF
--- a/heat/bmi_heat.c
+++ b/heat/bmi_heat.c
@@ -11,8 +11,8 @@
 #include <float.h>
 
 #include "heat.h"
+#include <bmi.h>
 #include "bmi_heat.h"
-
 
 #define INPUT_VAR_NAME_COUNT 1
 #define OUTPUT_VAR_NAME_COUNT 1

--- a/heat/bmi_main.c
+++ b/heat/bmi_main.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "heat.h"
+#include <bmi.h>
 #include "bmi_heat.h"
 
 

--- a/testing/test_conflicting_instances.c
+++ b/testing/test_conflicting_instances.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <heat.h>
+#include <bmi.h>
 #include <bmi_heat.h>
 
 

--- a/testing/test_get_value.c
+++ b/testing/test_get_value.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <heat.h>
+#include <bmi.h>
 #include <bmi_heat.h>
 
 

--- a/testing/test_grid_info.c
+++ b/testing/test_grid_info.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <heat.h>
+#include <bmi.h>
 #include <bmi_heat.h>
 
 

--- a/testing/test_initialize_from_file.c
+++ b/testing/test_initialize_from_file.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <math.h>
 
+#include <heat.h>
+#include <bmi.h>
 #include <bmi_heat.h>
 
 

--- a/testing/test_irf.c
+++ b/testing/test_irf.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <math.h>
 
+#include <heat.h>
+#include <bmi.h>
 #include <bmi_heat.h>
 
 

--- a/testing/test_print_var_names.c
+++ b/testing/test_print_var_names.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <heat.h>
+#include <bmi.h>
 #include <bmi_heat.h>
 
 

--- a/testing/test_reinitialize.c
+++ b/testing/test_reinitialize.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <math.h>
 
+#include <heat.h>
+#include <bmi.h>
 #include <bmi_heat.h>
 
 

--- a/testing/test_set_value.c
+++ b/testing/test_set_value.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <heat.h>
+#include <bmi.h>
 #include <bmi_heat.h>
 
 


### PR DESCRIPTION
The guards prevent multiple includes.