### PR TITLE
Install heat.h

### DIFF
--- a/heat/CMakeLists.txt
+++ b/heat/CMakeLists.txt
@@ -27,7 +27,7 @@ install(TARGETS bmiheatc
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
   COMPONENT heat)
-install(FILES bmi_heat.h
+install(FILES bmi_heat.h heat.h
         DESTINATION include
         COMPONENT heat)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/heatc.pc


### PR DESCRIPTION
The *heat.h* header file wasn't being installed, this pull request just adds it to the list of installed header files.