### PR TITLE
Run CI on Windows

### DIFF
--- a/.github/workflows/conda-and-cmake.yml
+++ b/.github/workflows/conda-and-cmake.yml
@@ -1,9 +1,9 @@
-name: conda-cmake-build
+name: Build/Test CI
 
 on: [push, pull_request]
 
 jobs:
-  build-and-test:
+  build-linux-and-macos:
     runs-on: ${{ matrix.os }}
 
     defaults:
@@ -27,8 +27,7 @@ jobs:
           channel-priority: true
 
       - name: Show conda installation info
-        run: |
-          conda info
+        run: conda info
 
       - name: Install build tools and dependencies into env
         run: |
@@ -49,3 +48,49 @@ jobs:
       - name: Test
         working-directory: ${{ github.workspace }}/build
         run: ctest -C ${{ matrix.build-type }} --output-on-failure
+
+  build-windows:
+    runs-on: windows-latest
+
+    env:
+      build-type: Release
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: 3.8
+          channels: conda-forge
+          channel-priority: true
+
+      - name: Show conda installation info
+        run: conda info
+
+      - name: Install build tools and dependencies into env
+        run: |
+          conda install c-compiler cmake pkg-config bmi-c
+          conda list
+
+      - name: Make cmake build directory
+        run: cmake -E make_directory build
+
+      - name: Configure, build, and test
+        shell: cmd /C CALL {0}
+        working-directory: ${{ github.workspace }}\build
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.16 10.0.19041.0
+
+          :: Configure
+          cmake ^
+            -LAH -G "NMake Makefiles" ^
+            -DPKG_CONFIG_EXECUTABLE:FILEPATH=C:/Miniconda/envs/test/Library/bin/pkg-config.exe ^
+            -DCMAKE_BUILD_TYPE=${{ env.build-type }} ^
+            ..
+
+          :: Build and install
+          cmake --build . --target install --config ${{ env.build-type }}
+
+          :: Test
+          ctest --output-on-failure -C ${{ env.build-type }} -V

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Basic Model Interface](https://img.shields.io/badge/CSDMS-Basic%20Model%20Interface-green.svg)](https://bmi.readthedocs.io/)
-![conda-cmake-build](https://github.com/csdms/bmi-example-c/workflows/conda-cmake-build/badge.svg)
+[![Build/Test CI](https://github.com/csdms/bmi-example-c/workflows/Build/Test%20CI/badge.svg)](https://github.com/csdms/bmi-example-c/actions?query=workflow%3A%22Build%2FTest+CI%22)
 
 # bmi-example-c
 


### PR DESCRIPTION
This PR updates the GitHub Actions CI workflow to build and test on Windows in addition to Linux and macOS.