### PR TITLE
Standardize diffusion model

### DIFF
--- a/heat/heat.c
+++ b/heat/heat.c
@@ -110,7 +110,7 @@ initialize_arrays (HeatModel *self)
     }
     for (i = 0; i < n_cols; i++) {
       self->z[0][i] = 0.;
-      self->z[n_rows-1][i] = top_x*top_x*.25 - (i-top_x*.5) * (i-top_x*.5);
+      self->z[n_rows-1][i] = 0.;
     }
 
     memcpy (self->temp_z[0], self->z[0], sizeof (double) * n_elements);


### PR DESCRIPTION
This PR is part of an attempt to standardize the diffusion model used in all four BMI examples. The model:

* uses a 2D uniform rectilinear grid
* has a random initial field
* has Dirichlet boundary conditions set to zero (temperature not conserved)
* uses a time step defined by a stability criterion: `dt = min(spacing)^2 / (4 * alpha)` 