### PR TITLE
Use full path CMake variables

### DIFF
--- a/heat/heatc.pc.cmake
+++ b/heat/heatc.pc.cmake
@@ -1,5 +1,5 @@
 Name: HeatC
 Description: 2D Heat Equation
 Version: ${CMAKE_PROJECT_VERSION}
-Libs: -L${CMAKE_INSTALL_LIBDIR} -l${bmi_name}
-Cflags: -I${CMAKE_INSTALL_INCLUDEDIR}
+Libs: -L${CMAKE_INSTALL_FULL_LIBDIR} -l${bmi_name}
+Cflags: -I${CMAKE_INSTALL_FULL_INCLUDEDIR}


### PR DESCRIPTION
This PR changes the template pkg-config file to use the `CMAKE_INSTALL_FULL_<dir>` variables instead of the `CMAKE_INSTALL_<dir>` variables used in the build process. See https://github.com/csdms/bmi-c/issues/9.