### PR TITLE
Improve project packaging

### DIFF
--- a/heat/CMakeLists.txt
+++ b/heat/CMakeLists.txt
@@ -1,4 +1,4 @@
-# heatc
+# heat
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/${model_name}.pc.cmake

--- a/heat/CMakeLists.txt
+++ b/heat/CMakeLists.txt
@@ -4,10 +4,16 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/${model_name}.pc.cmake
   ${CMAKE_BINARY_DIR}/heat/${model_name}.pc
 )
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/${bmi_name}.pc.cmake
+  ${CMAKE_BINARY_DIR}/heat/${bmi_name}.pc
+)
 
 if(WIN32)
+  add_library(${model_name} heat.c)
   add_library(${bmi_name} bmi_heat.c heat.c)
 else()
+  add_library(${model_name} SHARED heat.c)
   add_library(${bmi_name} SHARED bmi_heat.c heat.c)
 endif()
 
@@ -19,7 +25,7 @@ install(
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 install(
-  TARGETS ${bmi_name}
+  TARGETS ${model_name} ${bmi_name}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -29,6 +35,8 @@ install(
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/${model_name}.pc
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${model_name}.pc
+    ${CMAKE_CURRENT_BINARY_DIR}/${bmi_name}.pc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )

--- a/heat/bmiheatc.pc.cmake
+++ b/heat/bmiheatc.pc.cmake
@@ -1,0 +1,5 @@
+Name: BmiHeatC
+Description: BMI for HeatC model
+Version: ${CMAKE_PROJECT_VERSION}
+Cflags: -I${CMAKE_INSTALL_FULL_INCLUDEDIR}
+Libs: -L${CMAKE_INSTALL_FULL_LIBDIR} -l${bmi_name}

--- a/heat/heatc.pc.cmake
+++ b/heat/heatc.pc.cmake
@@ -1,5 +1,4 @@
 Name: HeatC
 Description: 2D Heat Equation
 Version: ${CMAKE_PROJECT_VERSION}
-Libs: -L${CMAKE_INSTALL_FULL_LIBDIR} -l${bmi_name}
 Cflags: -I${CMAKE_INSTALL_FULL_INCLUDEDIR}

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,4 +1,4 @@
-# test (heatc)
+# test (heat)
 
 include(CTest)
 


### PR DESCRIPTION
This PR includes some improvements to how this project is packaged, driven by a downstream need (https://github.com/mdpiper/pymt_heatc). Two noteworthy changes:

1. Include a pkg-config file for the BMI wrapped version of the HeatC model. This helps a downstream application find it.
2. Install the HeatC model as a library. I did this just to show that HeatC can be used independently of BmiHeatC.

I hadn't put much thought into how pkg-config works before this. I'm trying to correct that and do a better job here.